### PR TITLE
pin lint CI to python 3.13

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: "pyproject.toml"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: uv sync


### PR DESCRIPTION
tiktoken (via copychat) depends on pyo3 v0.22.6 which only supports up to Python 3.13. The lint workflow was using `python-version-file: "pyproject.toml"` which resolved to 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)